### PR TITLE
Adds the pkceEnabled key for RapidIdentity JSON file

### DIFF
--- a/configurations/v2.X/RapidIdentity-Identity_Automation/JamfConnect.json
+++ b/configurations/v2.X/RapidIdentity-Identity_Automation/JamfConnect.json
@@ -13,6 +13,7 @@
     "oidcConfig": {
         "enabled": true,
         "enableROPG": true,
+        "pkceEnabled" : true,
         "idTokenLifetime": 60,
         "claimAttributes": [
             {


### PR DESCRIPTION
Set pkceEnabled to true to ensure the configuration is created with PKCE enabled in compatible tenants. Otherwise, the OIDC test may fail. This setting may not be on by default when adding Jamf Connect as a federation partner, as discovered in a recent integration and confirmed by Identity Automation support.